### PR TITLE
0.1.7: additional info, refactoring, error logging

### DIFF
--- a/SebastianJ/monitoring/node_status.sh
+++ b/SebastianJ/monitoring/node_status.sh
@@ -365,6 +365,7 @@ check_network_status() {
           success_message "Your shard's latest recorded block is: ${bold_text}${current_network_block}${normal_text}"
         else
           error_message "Shard ${bold_text}${shard}${normal_text}${red_text} is: ${bold_text}${shard_status}${normal_text}"
+          warning_message "Please check @harmonypangaea on Telegram or the Discord #pangaea channel for network updates."
         fi
       fi
     fi


### PR DESCRIPTION
- Check and output build versions for harmony + wallet binary
- Parse currently used bootnodes
- Improve shard parsing (thanks to Agx10k)
- Add support for parsing the errors from latest/zerolog*.log and outputting in a separate logfile when running node_status.sh using -e
- Fix for correctly parsing the network page's timestamp