### PR TITLE
Cross shard TX script

### DIFF
--- a/crossshard.sh
+++ b/crossshard.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+while :
+    do
+fromshard=$(shuf -i 0-3 -n 1)
+echo my from shard=$fromshard >> crossshard.txt
+toshard=$(shuf -i 0-3 -n 1)
+echo my to shard=$toshard >> crossshard.txt
+
+filename='wallets.txt'
+n=1
+while read line; do
+# reading each line
+n=$((n+1))
+done < $filename
+
+date >> crossshard.txt && ./wallet.sh -t transfer --from one1lpezs3xgqr4smtdxfslpv3l48twyrez06cvx2k --to $filename --amount  0.001 --shardID=$fromshard --toShardID=$toshard --pass pass: | tee -a crossshard.txt
+
+sleep 5
+
+done

--- a/walletfetch.sh
+++ b/walletfetch.sh
@@ -1,0 +1,10 @@
+while :
+    do
+rm test.txt
+curl -s https://harmony.one/pga/network | sed -n  '/ONLINE/,/OFFLINE/p' >test.txt
+sleep 5
+rm wallets.txt
+grep 'one.*' test.txt >wallets.txt
+sleep 86400
+
+done


### PR DESCRIPTION
wallet fetch script
will fetch all online node from https://harmony.one/pga/network
you could change the curl to https://harmony.one/pga/balances and filter on earning and not earning
it generates a file called wallets.txt wich is needed in the crossshard.sh


Cross shard script

it generate a random shard nummer for send and receive
after that it reads out the wallets.txt file.
and after that it wil do the tx and writes output with a date to a file called crossshard.txt

output will be something like

my from shard=1
my to shard=0
Sun Sep 15 19:22:38 UTC 2019
Using pangaea profile for wallet
Unlock account succeeded! 'pass:'
Transaction Id for shard 1: 0xe8f82308b198cd0f7d8d43ba34c94a731a4e9259f74a719f2304d919424a9104